### PR TITLE
Adding LiteChain as an alternative LLM framework to LangChain

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,7 +297,8 @@ The above tables coule be better summarized by this wonderful visualization from
 
 - [Haystack](https://haystack.deepset.ai/) - an open-source NLP framework that allows you to use LLMs and transformer-based models from Hugging Face, OpenAI and Cohere to interact with your own data. 
 -  [Sidekick](https://github.com/ai-sidekick/sidekick) - Data integration platform for LLMs. 
-- [LangChain](https://github.com/hwchase17/langchain) -  Building applications with LLMs through composability 
+- [LangChain](https://github.com/hwchase17/langchain) -  Building applications with LLMs through composability
+- [LiteChain](https://github.com/rogeriochaves/litechain) - Lightweight alternative to LangChain for composing LLMs 
 -  [wechat-chatgpt](https://github.com/fuergaosi233/wechat-chatgpt) - Use ChatGPT On Wechat via wechaty
 - [promptfoo](https://github.com/typpo/promptfoo) - Test your prompts. Evaluate and compare LLM outputs, catch regressions, and improve prompt quality.
 - [Agenta](https://github.com/agenta-ai/agenta) -  Easily build, version, evaluate and deploy your LLM-powered apps.


### PR DESCRIPTION
Hello there, I'm proposing to add LiteChain, it is a lightweight alternative to LangChain, well documented and easy to get started and integrate with other tools

(disclaimer: it's my own project)