### PR TITLE
added Langroid under tools for deploying LLMs

### DIFF
--- a/README.md
+++ b/README.md
@@ -305,6 +305,7 @@ The above tables coule be better summarized by this wonderful visualization from
 - [Agenta](https://github.com/agenta-ai/agenta) -  Easily build, version, evaluate and deploy your LLM-powered apps.
 - [Serge](https://github.com/serge-chat/serge) - a chat interface crafted with llama.cpp for running Alpaca models. No API keys, entirely self-hosted!
 - [Embedchain](https://github.com/embedchain/embedchain) - Framework to create ChatGPT like bots over your dataset.
+- [Langroid](https://github.com/langroid/langroid) - Harness LLMs with Multi-Agent Programming.
 
 ## Tutorials about LLM
 - [Andrej Karpathy] State of GPT [video](https://build.microsoft.com/en-US/sessions/db3f4859-cd30-4445-a0cd-553c3304f8e2)


### PR DESCRIPTION
Hi @Hannibal046  I'm proposing adding Langroid. Full disclosure -- I am the lead dev on this 😃 

Quoting from the README of [Langroid](https://github.com/langroid/langroid):

`Langroid` is an intuitive, lightweight, extensible and principled Python framework to easily build LLM-powered applications. You set up Agents, equip them with optional components (LLM,  vector-store and methods), assign them tasks, and have them collaboratively solve a problem by exchanging messages. This Multi-Agent paradigm is inspired by the [Actor Framework](https://en.wikipedia.org/wiki/Actor_model) (but you do not need to know anything about this!). 

Langroid represents a fresh take on LLM app-development where considerable thought has gone into simplifying the developer experience. It does not use `Langchain` or `Llama-Index`.
