### PR TITLE
Add Mistral.ai Open LLM

### DIFF
--- a/README.md
+++ b/README.md
@@ -279,6 +279,8 @@ The above tables coule be better summarized by this wonderful visualization from
 - [XGen](https://github.com/salesforce/xgen) - Salesforce open-source LLMs with 8k sequence length.
 - [baichuan-7B](https://github.com/baichuan-inc/baichuan-7B) - baichuan-7B 是由百川智能开发的一个开源可商用的大规模预训练语言模型.
 - [Aquila](https://github.com/FlagAI-Open/FlagAI/tree/master/examples/Aquila) - 悟道·天鹰语言大模型是首个具备中英双语知识、支持商用许可协议、国内数据合规需求的开源语言大模型。
+- [Mistral](https://mistral.ai/) - Mistral-7B-v0.1 is a small, yet powerful model adaptable to many use-cases including code and 8k sequence length. Apache 2.0 licence.
+
 ## LLM Training Frameworks
 
 - [DeepSpeed](https://github.com/microsoft/DeepSpeed) - DeepSpeed is a deep learning optimization library that makes distributed training and inference easy, efficient, and effective.


### PR DESCRIPTION
This adds the Mistral LLM to the Awesome list.

* Mistral-7B-v0.1 is a small, yet powerful model adaptable to many use-cases. 
* Has natural coding abilities, and 8k sequence length. 
* It’s released under Apache 2.0 licence. 
 
See https://mistral.ai/
