### PR TITLE
docs: add AI Manifest + WellKnownAI as optional references (discoverability + snapshots)

### DIFF
--- a/README.md
+++ b/README.md
@@ -622,3 +622,9 @@ I will keep some pull requests open if I'm not sure if they are awesome for LLM,
 If you have any question about this opinionated list, do not hesitate to contact me chengxin1998@stu.pku.edu.cn.
 
 [^1]: This is not legal advice. Please contact the original authors of the models for more information.
+
+
+## Resources
+
+- [AI Manifest](https://ai-manifest.org) — optional reference for /.well‑known/ai.json + OpenAPI/JSON Schema discovery (with MCP/agents.json mapping).
+- [WellKnownAI](https://wellknownai.org) — registry/spec examples and public snapshots (no PII, mirroring allowed).

--- a/README.md
+++ b/README.md
@@ -624,7 +624,7 @@ If you have any question about this opinionated list, do not hesitate to contact
 [^1]: This is not legal advice. Please contact the original authors of the models for more information.
 
 
-## Resources
 
-- [AI Manifest](https://ai-manifest.org) — optional reference for /.well‑known/ai.json + OpenAPI/JSON Schema discovery (with MCP/agents.json mapping).
-- [WellKnownAI](https://wellknownai.org) — registry/spec examples and public snapshots (no PII, mirroring allowed).
+
+- [AI Manifest](https://ai-manifest.org) - Optional reference for /.well-known/ai.json + OpenAPI/JSON Schema discovery (with MCP/agents.json mapping).
+- [WellKnownAI](https://wellknownai.org) - Registry/spec examples and public snapshots (no PII, mirroring allowed).


### PR DESCRIPTION
Adding two optional references for service/agent discovery and auditability:

- AI Manifest — optional reference for /.well-known/ai.json + OpenAPI/JSON Schema discovery (with MCP/agents.json mapping). https://ai-manifest.org
- WellKnownAI — registry/spec examples and public snapshots (no PII, mirroring allowed). https://wellknownai.org

Non-binding, community-driven; alphabetical order respected where applicable.