### PR TITLE
Adding Sayna.ai, a self-hosted voice layer for AI Agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -533,6 +533,7 @@
 - [Arthur Shield](https://www.arthur.ai/get-started) — A paid product for detecting toxicity, hallucination, prompt injection, etc.
 - [LMQL](https://lmql.ai) — A programming language for LLM interaction with support for typed prompting, control flow, constraints, and tools.
 - [ModelFusion](https://github.com/lgrammel/modelfusion) - A TypeScript library for building apps with LLMs and other ML models (speech-to-text, text-to-speech, image generation).
+- [Sayna](https://github.com/SaynaAI/sayna) - Voice infrastructure for LLM-powered agents with unified API for speech-to-text, text-to-speech, and real-time audio streaming.
 - [OneKE](https://openspg.yuque.com/ndx6g9/ps5q6b/vfoi61ks3mqwygvy) — A bilingual Chinese-English knowledge extraction model with knowledge graphs and natural language processing technologies.
 - [llm-ui](https://github.com/llm-ui-kit/llm-ui) - A React library for building LLM UIs.
 - [Wordware](https://www.wordware.ai) - A web-hosted IDE where non-technical domain experts work with AI Engineers to build task-specific AI agents. We approach prompting as a new programming language rather than low/no-code blocks.


### PR DESCRIPTION
Adding [Sayna.ai](https://github.com/SaynaAI/sayna), which is a Rust-based self-hosted voice infrastructure for AI Agents. It handles everything that relates to the voice, like STT, TTS, SIP Telephony, Noise Suppression, TURN Taking, and nearly all providers for the voice. It is a great addition to the list, and a great way to get started with voice AI agents.