### PR TITLE
Fix broken 'State of GPT' link

### DIFF
--- a/README.md
+++ b/README.md
@@ -561,7 +561,7 @@
 - [ChatGPT Prompt Engineering](https://www.deeplearning.ai/short-courses/chatgpt-prompt-engineering-for-developers/)
 - [Princeton: Understanding Large Language Models](https://www.cs.princeton.edu/courses/archive/fall22/cos597G/)
 - [CS324 - Large Language Models](https://stanford-cs324.github.io/winter2022/)
-- [State of GPT](https://build.microsoft.com/en-US/sessions/db3f4859-cd30-4445-a0cd-553c3304f8e2)
+- [State of GPT](https://www.youtube.com/watch?v=bZQun8Y4L2A)
 - [A Visual Guide to Mamba and State Space Models](https://maartengrootendorst.substack.com/p/a-visual-guide-to-mamba-and-state?utm_source=multiple-personal-recommendations-email&utm_medium=email&open=false)
 - [Let's build GPT: from scratch, in code, spelled out.](https://www.youtube.com/watch?v=kCc8FmEb1nY)
 - [minbpe](https://www.youtube.com/watch?v=zduSFxRajkE&t=1157s) - Minimal, clean code for the Byte Pair Encoding (BPE) algorithm commonly used in LLM tokenization.


### PR DESCRIPTION
Fixes #202

The link to 'State of GPT' was pointing to a Microsoft Build session page that no longer exists. Replaced it with the working YouTube video URL for Andrej Karpathy's talk.