### PR TITLE
feat: Add rehydra to LLM Applications

### DIFF
--- a/README.md
+++ b/README.md
@@ -529,7 +529,7 @@
 - [PromptPerfect](https://promptperfect.jina.ai/prompts) — A paid product for testing and improving prompts.
 - [Weights & Biases](https://wandb.ai/site/solutions/llmops) — A paid product for tracking model training and prompt engineering experiments.
 - [OpenAI Evals](https://github.com/openai/evals) — An open-source library for evaluating task performance of language models and prompts.
-
+- [rehydra](https://github.com/rehydra-ai/rehydra-sdk) - A zero-trust SDK to anonymize PII locally before sending prompts to LLMs and seamlessly rehydrate the response.
 - [Arthur Shield](https://www.arthur.ai/get-started) — A paid product for detecting toxicity, hallucination, prompt injection, etc.
 - [LMQL](https://lmql.ai) — A programming language for LLM interaction with support for typed prompting, control flow, constraints, and tools.
 - [ModelFusion](https://github.com/lgrammel/modelfusion) - A TypeScript library for building apps with LLMs and other ML models (speech-to-text, text-to-speech, image generation).


### PR DESCRIPTION
## Summary
Adding `rehydra` to the LLM Applications section.

## About `rehydra`
**What**: A zero-trust privacy SDK for LLMs.

**How**: It allows developers to anonymize PII locally (using Regex/NER) before sending them to the provider, and then seamlessly "rehydrating" the (streaming) response to restore the original context.

**Why**: It solves the data sovereignty problem, allowing developers to use public models (like GPT-5.2) with sensitive client data without any PII leaving their infrastructure.

## Links
GitHub: https://github.com/rehydra-ai/rehydra-sdk

npm: https://www.npmjs.com/package/rehydra

## Why it fits "LLM Applications"
This tool belongs in LLM Applications as it functions as a middleware/safety layer for building apps. It sits logically alongside existing entries in this section like Guardrails.ai and Arthur Shield, which similarly handle validation and security for LLM inputs/outputs.