### PR TITLE
Add APIClaw - The API layer for AI agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -507,6 +507,7 @@
 - [Tune Studio](https://studio.tune.app/) - Playground for devs to finetune & deploy LLMs
 - [LLocalSearch](https://github.com/nilsherzig/LLocalSearch) - Locally running websearch using LLM chains
 - [AI Gateway](https://github.com/Portkey-AI/gateway) — Gateway streamlines requests to 100+ open & closed source models with a unified API. It is also production-ready with support for caching, fallbacks, retries, timeouts, loadbalancing, and can be edge-deployed for minimum latency.
+- [APIClaw](https://github.com/nordsym/apiclaw) — The API layer for AI agents. 22,000+ APIs indexed with semantic discovery and Direct Call execution via MCP. Giving agents access to real-world APIs. Discovery is free forever.
 - [talkd.ai dialog](https://github.com/talkdai/dialog) - Simple API for deploying any RAG or LLM that you want adding plugins.
 - [Wllama](https://github.com/ngxson/wllama) - WebAssembly binding for llama.cpp - Enabling in-browser LLM inference
 - [GPUStack](https://github.com/gpustack/gpustack) - An open-source GPU cluster manager for running LLMs


### PR DESCRIPTION
Adding APIClaw to the LLM Applications section.

## APIClaw
The API layer for AI agents — giving agents access to real-world APIs.

- **22,000+ APIs indexed** — Semantic discovery by capability
- **18 Direct Call providers** — Execute without API keys
- **MCP native** — Works with any MCP-compatible agent
- **Discovery is free forever** — Search, compare, evaluate at no cost

https://github.com/nordsym/apiclaw