### PR TITLE
Add kbot — open-source terminal AI agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -484,6 +484,7 @@
 - [dspy](https://github.com/stanfordnlp/dspy) - DSPy: The framework for programming—not prompting—foundation models.
 - [LangChain](https://github.com/hwchase17/langchain) — A popular Python/JavaScript library for chaining sequences of language model prompts.
 - [LlamaIndex](https://github.com/jerryjliu/llama_index) — A Python library for augmenting LLM apps with data.
+- [kbot](https://github.com/isaacsight/kernel) — An open-source terminal AI agent with 39 specialist agents, 167 tools, and 19 provider integrations. Local-first, self-evolving, multi-provider. Install via `npm install -g @kernel.chat/kbot`.
 
 <details>
 <summary>more applications</summary>


### PR DESCRIPTION
## Add kbot to LLM Applications section

[kbot](https://github.com/isaacsight/kernel) is an open-source terminal AI agent with 39 specialist agents, 167 built-in tools, and integrations for 19 AI providers.

- **MIT licensed**
- **Install**: `npm install -g @kernel.chat/kbot`
- **GitHub**: https://github.com/isaacsight/kernel
- **npm**: https://www.npmjs.com/package/@kernel.chat/kbot

kbot is a TypeScript/Node.js CLI tool that supports multi-provider LLM access (Anthropic, OpenAI, Google, DeepSeek, Mistral, Groq, local models via Ollama), self-evolving learning from interactions, and 167 built-in tools for file operations, git, GitHub, web search, browser automation, and MCP server support.