### PR TITLE
add Kronaxis Router to LLM Inference

### DIFF
--- a/README.md
+++ b/README.md
@@ -464,6 +464,7 @@
 - [MInference](https://github.com/microsoft/MInference) - To speed up Long-context LLMs' inference, approximate and dynamic sparse calculate the attention, which reduces inference latency by up to 10x for pre-filling on an A100 while maintaining accuracy.
 - [exllama](https://github.com/turboderp/exllama) - A more memory-efficient rewrite of the HF transformers implementation of Llama for use with quantized weights.
 - [FastChat](https://github.com/lm-sys/FastChat) - A distributed multi-model LLM serving system with web UI and OpenAI-compatible RESTful APIs.
+- [Kronaxis Router](https://github.com/Kronaxis/kronaxis-router) - Intelligent LLM proxy that auto-classifies prompts and routes to the cheapest capable model. Cost-based routing, batch API aggregation, response caching, budget enforcement. Single Go binary.
 - [mistral.rs](https://github.com/EricLBuehler/mistral.rs) - Blazingly fast LLM inference.
 - [SkyPilot](https://github.com/skypilot-org/skypilot) - Run LLMs and batch jobs on any cloud. Get maximum cost savings, highest GPU availability, and managed execution -- all with a simple interface.
 - [Haystack](https://haystack.deepset.ai/) - an open-source NLP framework that allows you to use LLMs and transformer-based models from Hugging Face, OpenAI and Cohere to interact with your own data. 


### PR DESCRIPTION
## Description

Add [Kronaxis Router](https://github.com/Kronaxis/kronaxis-router) to the LLM Inference section (under "other deployment tools").

Kronaxis Router is an intelligent LLM proxy that auto-classifies prompts and routes to the cheapest capable model. It sits in front of inference backends (vLLM, Ollama, cloud APIs) and provides cost-based routing, batch API aggregation, response caching, and budget enforcement. Single Go binary, Apache 2.0.

Similar to [AI Gateway](https://github.com/Portkey-AI/gateway) (already listed under LLM Applications) but focused on cost optimisation and local/cloud hybrid routing rather than provider unification.

## Checklist

- [x] Added in alphabetical position within the "other deployment tools" collapsible (between FastChat and mistral.rs)
- [x] Matches existing entry format: `- [Name](url) - Description.`
- [x] Open source (Apache-2.0)