### PR TITLE
Add BenchGecko to LLM Evaluation section

### DIFF
--- a/README.md
+++ b/README.md
@@ -401,6 +401,7 @@
 - [lm-evaluation-harness](https://github.com/EleutherAI/lm-evaluation-harness) - A framework for few-shot evaluation of language models.
 - [lighteval](https://github.com/huggingface/lighteval) - a lightweight LLM evaluation suite that Hugging Face has been using internally.
 - [simple-evals](https://github.com/openai/simple-evals) - Eval tools by OpenAI.
+- [BenchGecko](https://benchgecko.ai) - CoinGecko for AI. Compare 414+ LLMs across 40 benchmarks (MMLU, HumanEval, GSM8K, etc.) with a free API. [[API]](https://benchgecko.ai/api/v1)
 
 <details>
 <summary>other evaluation frameworks</summary>

--- a/README.md
+++ b/README.md
@@ -401,7 +401,7 @@
 - [lm-evaluation-harness](https://github.com/EleutherAI/lm-evaluation-harness) - A framework for few-shot evaluation of language models.
 - [lighteval](https://github.com/huggingface/lighteval) - a lightweight LLM evaluation suite that Hugging Face has been using internally.
 - [simple-evals](https://github.com/openai/simple-evals) - Eval tools by OpenAI.
-- [BenchGecko](https://benchgecko.ai) - CoinGecko for AI. Compare 414+ LLMs across 40 benchmarks (MMLU, HumanEval, GSM8K, etc.) with a free API. [[API Docs]](https://benchgecko.ai/api-docs)
+- [BenchGecko](https://benchgecko.ai) - AI benchmark and pricing data. Compare 414+ LLMs across 40 benchmarks (MMLU, HumanEval, GSM8K, etc.) with a free API. Every model. Every agent. Everything AI. Tracked. [[API Docs]](https://benchgecko.ai/api-docs)
 
 <details>
 <summary>other evaluation frameworks</summary>

--- a/README.md
+++ b/README.md
@@ -401,7 +401,7 @@
 - [lm-evaluation-harness](https://github.com/EleutherAI/lm-evaluation-harness) - A framework for few-shot evaluation of language models.
 - [lighteval](https://github.com/huggingface/lighteval) - a lightweight LLM evaluation suite that Hugging Face has been using internally.
 - [simple-evals](https://github.com/openai/simple-evals) - Eval tools by OpenAI.
-- [BenchGecko](https://benchgecko.ai) - CoinGecko for AI. Compare 414+ LLMs across 40 benchmarks (MMLU, HumanEval, GSM8K, etc.) with a free API. [[API]](https://benchgecko.ai/api/v1)
+- [BenchGecko](https://benchgecko.ai) - CoinGecko for AI. Compare 414+ LLMs across 40 benchmarks (MMLU, HumanEval, GSM8K, etc.) with a free API. [[API Docs]](https://benchgecko.ai/api-docs)
 
 <details>
 <summary>other evaluation frameworks</summary>


### PR DESCRIPTION
Adding BenchGecko to the LLM Evaluation section.

BenchGecko provides a free API for comparing LLM benchmarks, pricing, and capabilities across 414+ models and 55 providers. Useful for researchers and engineers choosing between models.

Endpoints include model listings with filtering, detailed benchmark scores, leaderboards, and side-by-side comparisons.

- Website: https://benchgecko.ai
- Free API: https://benchgecko.ai/api/v1
- No API key required for basic use