### PR TITLE
Add rl-router to LLM Inference

### DIFF
--- a/README.md
+++ b/README.md
@@ -457,6 +457,7 @@
 - [ollama](https://github.com/ollama/ollama) - Get up and running with Llama 3, Mistral, Gemma, and other large language models.
 - [TGI](https://huggingface.co/docs/text-generation-inference/en/index) - a toolkit for deploying and serving Large Language Models (LLMs).
 - [TensorRT-LLM](https://github.com/NVIDIA/TensorRT-LLM) - Nvidia Framework for LLM Inference
+- [rl-router](https://github.com/ElromEvedElElyon/rl-router) - Contextual Thompson Sampling router for multi-provider LLM APIs. Adapts to rate limits and failures across OpenAI, Anthropic, Google, and local models. Zero config, zero deps.
 <details>
 <summary>other deployment tools</summary>
 


### PR DESCRIPTION
This PR adds rl-router to the LLM Inference section.

What it is: A zero-dependency Python library that routes LLM requests across multiple providers (OpenAI, Anthropic, Google, local) using Contextual Thompson Sampling, automatically adapting to rate limits, latency shifts, and provider failures.

Differentiator: Fills a gap between single-provider inference engines (vLLM, TGI) and heavier orchestration layers (LiteLLM, Helicone). Pure Python 3.9+, MIT, zero external dependencies.

Repository: https://github.com/ElromEvedElElyon/rl-router