### PR TITLE
Add REG-Vault (retro-gaming metadata + MCP)

### DIFF
--- a/README.md
+++ b/README.md
@@ -622,3 +622,5 @@ I will keep some pull requests open if I'm not sure if they are awesome for LLM,
 If you have any question about this opinionated list, do not hesitate to contact me chengxin1998@stu.pku.edu.cn.
 
 [^1]: This is not legal advice. Please contact the original authors of the models for more information.
+
+- [REG-Vault MCP](https://regvault.org/docs/api) - MCP server for retro-gaming metadata (91k games, 99 systems). Drop-in for Claude Desktop / Cursor / Continue.


### PR DESCRIPTION
Adds **REG-Vault** — an open retro-gaming metadata catalog (91,000+ games, 99 systems) with REST API + MCP server at `api.regvault.org/mcp`.

- Home: https://regvault.org
- API docs: https://regvault.org/docs/api
- MCP endpoint: https://api.regvault.org/mcp (JSON-RPC 2.0, spec 2025-03-26)

Tools exposed: `list_systems`, `search_games`, `get_game`, `get_letter_counts`, `get_stats`.
