### PR TITLE
Add PromptUnit SDK — drop-in OpenAI client with automatic model routing

### DIFF
--- a/README.md
+++ b/README.md
@@ -507,6 +507,7 @@
 - [Tune Studio](https://studio.tune.app/) - Playground for devs to finetune & deploy LLMs
 - [LLocalSearch](https://github.com/nilsherzig/LLocalSearch) - Locally running websearch using LLM chains
 - [AI Gateway](https://github.com/Portkey-AI/gateway) — Gateway streamlines requests to 100+ open & closed source models with a unified API. It is also production-ready with support for caching, fallbacks, retries, timeouts, loadbalancing, and can be edge-deployed for minimum latency.
+- [PromptUnit SDK](https://github.com/promptunit/sdk) - Drop-in OpenAI client that routes LLM calls to cheaper models automatically, with built-in failover. 40-70% cost reduction, zero code change.
 - [talkd.ai dialog](https://github.com/talkdai/dialog) - Simple API for deploying any RAG or LLM that you want adding plugins.
 - [Wllama](https://github.com/ngxson/wllama) - WebAssembly binding for llama.cpp - Enabling in-browser LLM inference
 - [GPUStack](https://github.com/gpustack/gpustack) - An open-source GPU cluster manager for running LLMs


### PR DESCRIPTION
## What this adds

[PromptUnit SDK](https://github.com/promptunit/sdk) — a drop-in OpenAI client for Node.js/TypeScript that automatically routes LLM calls to cheaper models with built-in failover.

Added to the **LLM Applications** section alongside AI Gateway and similar routing tools.

**Why it belongs here:**
- Production-ready SDK (npm: )
- Solves the model routing problem transparently — your code never changes
- 40-70% cost reduction on real workloads
- MIT license