### PR TITLE
Add Entroly to LLM Applications

### DIFF
--- a/README.md
+++ b/README.md
@@ -605,7 +605,7 @@
 - [Cohere Summarize Beta](https://txt.cohere.ai/summarize-beta/) - Introducing Cohere Summarize Beta: A New Endpoint for Text Summarization
 - [chatgpt-wrapper](https://github.com/mmabrouk/chatgpt-wrapper) - ChatGPT Wrapper is an open-source unofficial Python API and CLI that lets you interact with ChatGPT.
 - [Cursor](https://www.cursor.so) - Write, edit, and chat about your code with a powerful AI.
-- [Entroly](https://github.com/juyterman1000/entroly) - Information-theoretic context compression proxy for AI coding agents. Uses Rust knapsack optimization to compress codebase context by 78% with zero quality loss.
+- [Entroly](https://github.com/juyterman1000/entroly) - Local-first MCP server for explicit-budget context selection, content-addressed exact recovery, and auditable Context Receipts.
 - [AutoGPT](https://github.com/Significant-Gravitas/Auto-GPT) - an experimental open-source application showcasing the capabilities of the GPT-4 language model. 
 - [OpenAGI](https://github.com/agiresearch/OpenAGI) - When LLM Meets Domain Experts.
 - [EasyEdit](https://github.com/zjunlp/EasyEdit) - An easy-to-use framework to edit large language models.

--- a/README.md
+++ b/README.md
@@ -605,6 +605,7 @@
 - [Cohere Summarize Beta](https://txt.cohere.ai/summarize-beta/) - Introducing Cohere Summarize Beta: A New Endpoint for Text Summarization
 - [chatgpt-wrapper](https://github.com/mmabrouk/chatgpt-wrapper) - ChatGPT Wrapper is an open-source unofficial Python API and CLI that lets you interact with ChatGPT.
 - [Cursor](https://www.cursor.so) - Write, edit, and chat about your code with a powerful AI.
+- [Entroly](https://github.com/juyterman1000/entroly) - Information-theoretic context compression proxy for AI coding agents. Uses Rust knapsack optimization to compress codebase context by 78% with zero quality loss.
 - [AutoGPT](https://github.com/Significant-Gravitas/Auto-GPT) - an experimental open-source application showcasing the capabilities of the GPT-4 language model. 
 - [OpenAGI](https://github.com/agiresearch/OpenAGI) - When LLM Meets Domain Experts.
 - [EasyEdit](https://github.com/zjunlp/EasyEdit) - An easy-to-use framework to edit large language models.


### PR DESCRIPTION
Adds Entroly to the LLM Applications list.

Entroly is an Apache-2.0, local-first MCP server for explicit-budget context selection, content-addressed exact recovery, and auditable Context Receipts.

Project: https://github.com/juyterman1000/entroly
Verification command: `entroly verify-claims`

Reduction varies by workload and budget; this listing does not claim a universal savings or quality percentage.