### PR TITLE
Add AgentLens to LLM Applications

### DIFF
--- a/README.md
+++ b/README.md
@@ -548,6 +548,7 @@
 - [Agentic Radar](https://github.com/splx-ai/agentic-radar) - Open-source CLI security scanner for agentic workflows. Scans your workflow’s source code, detects vulnerabilities, and generates an interactive visualization along with a detailed security report. Supports LangGraph, CrewAI, n8n, OpenAI Agents, and more.
 - [LangWatch](https://github.com/langwatch/langwatch) - Open-source LLM observability, prompt evaulation, and prompt optimzation platform.
 - [TensorZero](https://www.tensorzero.com/) - TensorZero is an open-source framework for building production-grade LLM applications. It unifies an LLM gateway, observability, optimization, evaluations, and experimentation.
+-  [AgentLens](https://github.com/Soufianeazz/agentlens) - Self-hosted LLM observability with built-in air-gap mode. Quality scoring, agent waterfalls, prompt debugger, GDPR-native compliance workflows. BSL 1.1 server + MIT SDK. 
 
 </details>
 


### PR DESCRIPTION
Adds AgentLens to the LLM Applications subsection.

AgentLens is a self-hosted LLM observability platform built for production teams that need air-gap mode (regulated industries) and GDPR-native compliance. Sits naturally alongside Langfuse and Arize-Phoenix in this category.

- Repo: https://github.com/Soufianeazz/agentlens
- Live demo: https://www.agentlens.one
- License: BSL 1.1 server + MIT SDK

Entry placed at the end of the section per current addition-order convention.