### PR TITLE
Add XFMS — LLM selection by aggregated benchmark evidence

### DIFF
--- a/README.md
+++ b/README.md
@@ -401,6 +401,7 @@
 - [lm-evaluation-harness](https://github.com/EleutherAI/lm-evaluation-harness) - A framework for few-shot evaluation of language models.
 - [lighteval](https://github.com/huggingface/lighteval) - a lightweight LLM evaluation suite that Hugging Face has been using internally.
 - [simple-evals](https://github.com/openai/simple-evals) - Eval tools by OpenAI.
+- [XFMS](https://github.com/VisionAIrySE/XFMS) - Pick the right LLM for your task. Hosted recommender that aggregates 8 independent benchmark sources (no provider self-reports), returns a ranked shortlist with plain-English rationale per pick. Python client (`pip install xfms`) + CLI; BYOK so your inference cost stays with you. Part of the [Xpansion Framework](https://xpansion.dev).
 
 <details>
 <summary>other evaluation frameworks</summary>


### PR DESCRIPTION
Adding XFMS — a hosted LLM recommender that aggregates evidence from 8
independent third-party benchmark sources (HuggingFace Open LLM
Leaderboard, Artificial Analysis, LMSys Chatbot Arena, LiveBench,
Creative Writing v3, EQ-Bench v3, BigCodeBench, Aider Polyglot) and
ranks models for a stated purpose with plain-English rationale per
pick.

XFMS is the model-selection module of the Xpansion Framework
(https://xpansion.dev). The hosted recommender at xfms.vercel.app
runs the math; this repository ships the Python client and CLI
(`pip install xfms`).

Differentiators:
- No provider self-reported scores accepted as input
- User intent overrides LLM-inferred weights at scoring time
- Honest gap surfacing (no interpolation, no synthetic scores)
- BYOK: callers supply their own OpenRouter key so inference cost
  rides with them, not the host
- Public methodology at docs/methodology.md — every claim maps to
  code that runs at request time

I placed it in the LLM Evaluation section since the audience overlap
is closest there — XFMS isn't itself an evaluation framework but it's
a meta-tool that uses evaluation results to recommend models. Happy
to move it to another section if you'd prefer.

Live on PyPI: https://pypi.org/project/xfms/
Repo: https://github.com/VisionAIrySE/XFMS

License: MIT.