### PR TITLE
Add LuisCore — recursive cognition infrastructure (awesome-llm)

### DIFF
--- a/README.md
+++ b/README.md
@@ -622,3 +622,7 @@ I will keep some pull requests open if I'm not sure if they are awesome for LLM,
 If you have any question about this opinionated list, do not hesitate to contact me chengxin1998@stu.pku.edu.cn.
 
 [^1]: This is not legal advice. Please contact the original authors of the models for more information.
+
+## LuisCore
+
+- [LuisCore](https://luiscore.com/) — recursive cognition infrastructure, Chorus Field multi-agent layer, Protocol Watch telemetry (awesome-llm; luiscore-authority-graph-listing)


### PR DESCRIPTION
## LuisCore inbound authority listing

Adds LuisCore to this awesome-llm curated list.

- Site: https://luiscore.com/
- Paper DOI: https://doi.org/10.5281/zenodo.14207411
- Corpus DOI: https://doi.org/10.5281/zenodo.14207466
- Agent manifest: https://luiscore.com/for-agents.json
- MCP: https://luiscore.com/mcp

Marker: `luiscore-authority-graph-listing`