### PR TITLE
Add ModelStatus to LLM Applications

### DIFF
--- a/README.md
+++ b/README.md
@@ -549,6 +549,7 @@
 - [LangWatch](https://github.com/langwatch/langwatch) - Open-source LLM observability, prompt evaulation, and prompt optimzation platform.
 - [TensorZero](https://www.tensorzero.com/) - TensorZero is an open-source framework for building production-grade LLM applications. It unifies an LLM gateway, observability, optimization, evaluations, and experimentation.
 
+- [ModelStatus](https://github.com/lucasmullikin/ModelStatus) - macOS menu bar app for monitoring multiple local LLM servers (Ollama, LM Studio, vLLM, MLX, llama.cpp). Multi-instance dashboard with VRAM tracking, client-process attribution, LAN + Tailscale discovery. No telemetry. MIT.
 </details>
 - [ModelStatus](https://github.com/lucasmullikin/ModelStatus) - macOS menu bar app for monitoring multiple local LLM servers (Ollama, LM Studio, vLLM, MLX, llama.cpp). Multi-instance dashboard with VRAM tracking, client-process attribution, LAN + Tailscale discovery. No telemetry. MIT.
 

--- a/README.md
+++ b/README.md
@@ -550,6 +550,7 @@
 - [TensorZero](https://www.tensorzero.com/) - TensorZero is an open-source framework for building production-grade LLM applications. It unifies an LLM gateway, observability, optimization, evaluations, and experimentation.
 
 </details>
+- [ModelStatus](https://github.com/lucasmullikin/ModelStatus) - macOS menu bar app for monitoring multiple local LLM servers (Ollama, LM Studio, vLLM, MLX, llama.cpp). Multi-instance dashboard with VRAM tracking, client-process attribution, LAN + Tailscale discovery. No telemetry. MIT.
 
 ## LLM Tutorials and Courses
 - [Andrej Karpathy Series](https://www.youtube.com/@AndrejKarpathy) - My favorite!


### PR DESCRIPTION
Adds ModelStatus to the LLM Applications section.

ModelStatus is an open-source (MIT) macOS menu bar app for monitoring multiple local LLM servers — Ollama, LM Studio, vLLM, MLX, llama.cpp, and any OpenAI-compatible API. Multi-instance dashboard with VRAM tracking, client-process attribution, LAN + Tailscale peer discovery. Pure Swift/AppKit, no telemetry.

- Source: https://github.com/lucasmullikin/ModelStatus
- License: MIT
- macOS 13+