### PR TITLE
Add QVAC SDK to LLM Inference section

### DIFF
--- a/README.md
+++ b/README.md
@@ -457,6 +457,7 @@
 - [ollama](https://github.com/ollama/ollama) - Get up and running with Llama 3, Mistral, Gemma, and other large language models.
 - [TGI](https://huggingface.co/docs/text-generation-inference/en/index) - a toolkit for deploying and serving Large Language Models (LLMs).
 - [TensorRT-LLM](https://github.com/NVIDIA/TensorRT-LLM) - Nvidia Framework for LLM Inference
+- [QVAC SDK](https://github.com/tetherto/qvac) - Cross-platform local AI SDK (JS/TS) running LLMs, embeddings, Whisper, TTS, OCR, image generation.
 <details>
 <summary>other deployment tools</summary>
 


### PR DESCRIPTION
Adding QVAC SDK to the LLM Inference list.

QVAC is a cross-platform JS/TS SDK for local AI inference that fills a gap not covered by the current entries: native mobile support (iOS + Android) alongside desktop and server, with a single npm install. It also supports on-device LoRA fine-tuning on phones, which no other listed project does.

- Repo: https://github.com/tetherto/qvac
- npm: @qvac/sdk
- License: Apache 2.0
- Stars: 186 and growing
- Last commit: this week

Disclosure: I work at QVAC (Tether AI).