### PR TITLE
Add mlx-serve to LLM Inference

### DIFF
--- a/README.md
+++ b/README.md
@@ -475,6 +475,7 @@
 - [Liger-Kernel](https://github.com/linkedin/Liger-Kernel) - Efficient Triton Kernels for LLM Training.
 - [prima.cpp](https://github.com/Lizonghang/prima.cpp) - A distributed implementation of llama.cpp that lets you run 70B-level LLMs on your everyday devices.
 - [deploy-llms-with-ansible](https://github.com/xamey/deploy-llms-with-ansible) - Easily deploy any LLM on a VM with minimal configuration, using Ansible.
+- [mlx-serve](https://github.com/ddalcu/mlx-serve) - Native Apple-Silicon LLM inference server (Zig, no Python). OpenAI- and Anthropic-compatible APIs, runs MLX and GGUF models, with speculative decoding and KV-cache quantization.
 
 </details>
 


### PR DESCRIPTION
Adds [mlx-serve](https://github.com/ddalcu/mlx-serve) to **LLM Inference → other deployment tools**.

A native **Apple-Silicon** LLM inference server written in **Zig** (no Python): **OpenAI- and Anthropic-compatible** APIs, runs MLX-format models *and* GGUF (embedded llama.cpp), with speculative decoding and KV-cache quantization. MIT-licensed.