### PR TITLE
Add ModelPriceWatch (live LLM API pricing) to Miscellaneous

### DIFF
--- a/README.md
+++ b/README.md
@@ -598,6 +598,7 @@
 ## Miscellaneous
 
 
+- [ModelPriceWatch](https://modelpricewatch.com/?utm_source=awesome-llm&utm_medium=readme&utm_campaign=awesome-llm) - Live pricing tracker for 150+ LLM APIs across 24 providers; auto-updates input/output $/Mtok so the numbers never go stale.
 - [Emergent Mind](https://www.emergentmind.com) - The latest AI news, curated & explained by GPT-4.
 - [ShareGPT](https://sharegpt.com) - Share your wildest ChatGPT conversations with one click.
 - [Major LLMs + Data Availability](https://docs.google.com/spreadsheets/d/1bmpDdLZxvTCleLGVPgzoMTQ0iDP2-7v7QziPrzPdHyM/edit#gid=0)

--- a/README.md
+++ b/README.md
@@ -598,7 +598,7 @@
 ## Miscellaneous
 
 
-- [ModelPriceWatch](https://modelpricewatch.com/?utm_source=awesome-llm&utm_medium=readme&utm_campaign=awesome-llm) - Live pricing tracker for 150+ LLM APIs across 24 providers; auto-updates input/output $/Mtok so the numbers never go stale.
+- [ModelPriceWatch](https://modelpricewatch.com/) - Live pricing tracker for 150+ LLM APIs across 24 providers; auto-updates input/output $/Mtok so the numbers never go stale.
 - [Emergent Mind](https://www.emergentmind.com) - The latest AI news, curated & explained by GPT-4.
 - [ShareGPT](https://sharegpt.com) - Share your wildest ChatGPT conversations with one click.
 - [Major LLMs + Data Availability](https://docs.google.com/spreadsheets/d/1bmpDdLZxvTCleLGVPgzoMTQ0iDP2-7v7QziPrzPdHyM/edit#gid=0)


### PR DESCRIPTION
Hi — thanks for maintaining Awesome-LLM; it's a go-to map of the ecosystem for a lot of us.

**Disclosure:** I maintain ModelPriceWatch, so this adds a project I'm affiliated with — flagging up front per self-promotion norms. Totally fine to decline, move it, or reword.

The list doesn't currently have a pricing/cost reference, and "what does each API actually cost" is a question that comes up constantly. [ModelPriceWatch](https://modelpricewatch.com) tracks input/output $/Mtok for 150+ LLM APIs across 24 providers and auto-updates from provider pricing pages, so the numbers don't go stale.

I've added a single plain-text entry under **Miscellaneous**, matching the list's existing `[name](url) - description` format (no badge/image). Happy to move it to a better-fitting section or trim the description.
