### PR TITLE
Add AI Model Watch to Miscellaneous

### DIFF
--- a/README.md
+++ b/README.md
@@ -610,6 +610,7 @@
 - [EasyEdit](https://github.com/zjunlp/EasyEdit) - An easy-to-use framework to edit large language models.
 - [chatgpt-shroud](https://github.com/guyShilo/chatgpt-shroud) - A Chrome extension for OpenAI's ChatGPT, enhancing user privacy by enabling easy hiding and unhiding of chat history. Ideal for privacy during screen shares.
 - [AI For Developers](https://aifordevelopers.org) - List of AI Tools and Agents for Developers
+- [AI Model Watch](https://aimodelwatch.dev) - Live tracker of AI/LLM model prices, context windows, and end-of-life / deprecation dates across providers, with a free open dataset and email alerts.
 
 ## Contributing
 


### PR DESCRIPTION
Adds one entry to the **Miscellaneous** section:

> [AI Model Watch](https://aimodelwatch.dev) - Live tracker of AI/LLM model prices, context windows, and end-of-life / deprecation dates across providers, with a free open dataset and email alerts.

Why it fits: it's a free, continuously-updated reference for LLM API pricing (USD per 1M tokens), context-window sizes, and — the part that's hard to find elsewhere — official deprecation / end-of-life dates across Anthropic, OpenAI, Google, DeepSeek, Alibaba and others. Sits naturally alongside existing entries like *Major LLMs + Data Availability* and *AI For Developers*.

The underlying catalog is published as an open dataset, and all prices/dates are sourced from official provider pages. No affiliation with other listed projects; single-line addition, no reordering.