### PR TITLE
Add wechat-mac-rpa to LLM Applications

### DIFF
--- a/README.md
+++ b/README.md
@@ -494,6 +494,7 @@
 - [LiteChain](https://github.com/rogeriochaves/litechain) - Lightweight alternative to LangChain for composing LLMs 
 - [magentic](https://github.com/jackmpcollins/magentic) - Seamlessly integrate LLMs as Python functions
 - [wechat-chatgpt](https://github.com/fuergaosi233/wechat-chatgpt) - Use ChatGPT On Wechat via wechaty
+- [wechat-mac-rpa](https://github.com/wq19901103wq/wechat-mac-rpa) - Visual AI agent for WeChat automation on macOS — no protocol reverse engineering, no database access, uses multimodal vision perception and LLM with memory system and multi-agent architecture
 - [promptfoo](https://github.com/typpo/promptfoo) - Test your prompts. Evaluate and compare LLM outputs, catch regressions, and improve prompt quality.
 - [Agenta](https://github.com/agenta-ai/agenta) -  Easily build, version, evaluate and deploy your LLM-powered apps.
 - [Serge](https://github.com/serge-chat/serge) - a chat interface crafted with llama.cpp for running Alpaca models. No API keys, entirely self-hosted!


### PR DESCRIPTION
## What is this?

[wechat-mac-rpa](https://github.com/wq19901103wq/wechat-mac-rpa) is a visual AI agent for WeChat automation on macOS. It uses multimodal vision perception and LLM to 'see' the WeChat interface and auto-reply messages — no protocol reverse engineering, no database access.

### Key Features
- **Visual AI Perception**: Uses multimodal LLM vision to understand WeChat UI — no protocol hacking, no database access
- **Memory System**: Vector database for conversation memory and context retention
- **Multi-Agent Architecture**: Supports digital twin and multi-agent orchestration
- **Skill System**: Extensible skills for smart home control, 3D printing, and more
- **Tech Stack**: Python / AppleScript / Multimodal LLM / Vector Database

### Where it fits
Added under **LLM Applications** section, next to the existing `wechat-chatgpt` entry, as both are WeChat + LLM applications.

### License
MIT License